### PR TITLE
updated Travis status image

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-[![Travis Build Status](https://api.travis-ci.org/yosethegame/yosethegame.png)](http://travis-ci.org/yosethegame/yosethegame)
+[![Travis Build Status](https://travis-ci.org/yosethegame/yosethegame.png?branch=master)](https://travis-ci.org/yosethegame/yosethegame)
 
 You've got Nutella on your nose :) 
 


### PR DESCRIPTION
Hi Eric,
in some tests I did it looked like the URL you're using for the Travis image doesn't always get updated. 

Maybe I'm wrong. Just in case you may want to force a build error, see if the image gets updated and get the compilation OK again. Or maybe it's just because the image gets cached by Github for a little while.

If you click in the right side icon in https://travis-ci.org/yosethegame/yosethegame you'll see this is the recommend URL.

Cheers.
